### PR TITLE
Allow PHP-Parser 4.0.1

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -4,7 +4,7 @@
     "license": "MIT",
     "require": {
         "php": ">=7.1,<7.3.0",
-        "nikic/php-parser": "4.0.x-dev",
+        "nikic/php-parser": "~4.0.1",
         "phpdocumentor/reflection-docblock": "^4.1.1",
         "phpdocumentor/type-resolver": "^0.4.0",
         "roave/signature": "^1.0"


### PR DESCRIPTION
While updating https://github.com/rectorphp/rector/pull/392, I got an error:

```
  Problem 1
    - Removal request for nikic/php-parser == 4.0.9999999.9999999-dev
    - rector/better-reflection v3.0.6 requires nikic/php-parser 4.0.x-dev -> satisfiable by nikic/php-parser[4.0.x-dev].
    - rector/better-reflection v3.0.6 requires nikic/php-parser 4.0.x-dev -> satisfiable by nikic/php-parser[4.0.x-dev].
    - Removal request for nikic/php-parser == 4.0.9999999.9999999-dev
    - Installation request for rector/better-reflection ^3.0.6 -> satisfiable by rector/better-reflection[v3.0.6].

```